### PR TITLE
corrected typo in Christian Cachin's name

### DIFF
--- a/_posts/2020-09-19-living-with-asynchrony-brachas-reliable-broadcast.markdown
+++ b/_posts/2020-09-19-living-with-asynchrony-brachas-reliable-broadcast.markdown
@@ -80,7 +80,7 @@ Bracha used Reliable Broadcast to improve Ben-Or's [Asynchonrus Byzanitne Agreem
 Reliable broadcast requires sending $O(n^2)$ messages that contain the value $v$.  In the next post of this series, we will see what we can improve if we allow using collision-resistant hash functions. 
 
 
-Cristian Cachin has [excellent course notes](https://dcl.epfl.ch/site/_media/education/sdc_byzconsensus.pdf) on Byzantine Broadcasts and Randomized Consensus including Bracha's Reliable broadcast.
+Christian Cachin has [excellent course notes](https://dcl.epfl.ch/site/_media/education/sdc_byzconsensus.pdf) on Byzantine Broadcasts and Randomized Consensus including Bracha's Reliable broadcast.
 
 
 

--- a/_posts/2022-12-12-what-about-validity.md
+++ b/_posts/2022-12-12-what-about-validity.md
@@ -4,7 +4,7 @@ date: 2022-12-12 04:00:00 -05:00
 tags:
 - dist101
 - lowerbound
-author: Ittai Abraham and Cristian Cachin
+author: Ittai Abraham and Christian Cachin
 ---
 
 Perhaps the architipical [trilemma](https://twitter.com/el33th4xor/status/1191820205456023552?s=20&t=RcutJw0wQUsTmrO0OXzpXw) is **consensus** - it requires three properties: **agreement**, **liveness**, and **validity**. Getting any two is easy, but all three together is what makes consensus such a facinating problem that continues to create new challenges even after 40 years of research.


### PR DESCRIPTION
fixed typo in Christian Cachin's name (mistakenly spelled Cristian).
